### PR TITLE
Fix dihedral angle calculation and test

### DIFF
--- a/biomod/core/atoms.py
+++ b/biomod/core/atoms.py
@@ -1,4 +1,5 @@
 import numpy as np
+import math
 from .math import rotation_matrix
 from .constants import PERIODIC_TABLE, ATOMIC_NUMBER, COVALENT_RADII, METALS
 
@@ -328,7 +329,8 @@ class Atom:
         v3 = p4 - p3
         n1 = np.cross(v1, v2)
         n2 = np.cross(v2, v3)
-        angle = np.degrees(np.arctan2(np.dot(v1, n2), np.dot(n1, n2)))
+        v2_norm = np.linalg.norm(v2)
+        angle = np.degrees(math.atan2(np.dot(v1, n2) * v2_norm, np.dot(n1, n2)))
         return angle
 
 

--- a/tests/core/test_dihedral_modification.py
+++ b/tests/core/test_dihedral_modification.py
@@ -71,9 +71,9 @@ class TestDihedralModification:
 
     def test_can_set_chi(self):
         arg_atoms = [
-            Atom("N", 0,0,0, 1, "N", 0,0,[]), Atom("CA", 0,1,0, 2, "CA", 0,0,[]),
-            Atom("CB", 1,1,0, 3, "CB", 0,0,[]), Atom("CG", 2,2,0, 4, "CG", 0,0,[]),
-            Atom("CD", 3,2,1, 5, "CD", 0,0,[]),
+            Atom("N", 0,0,0, 1, "N", 0,0,[]), Atom("C", 0,1,0, 2, "CA", 0,0,[]),
+            Atom("C", 1,1,0, 3, "CB", 0,0,[]), Atom("C", 2,2,0, 4, "CG", 0,0,[]),
+            Atom("C", 3,2,1, 5, "CD", 0,0,[]),
         ]
         arg = Residue(*arg_atoms, name="ARG", id="A1")
         arg.infer_bonds()


### PR DESCRIPTION
The dihedral angle calculation in 'biomod/core/atoms.py' was returning inaccurate results due to a precision issue in the formula. This was fixed by using a more robust formula that includes the length of the central bond vector.

The test 'tests/core/test_dihedral_modification.py::TestDihedralModification::test_can_set_chi' was also fixed. The test was failing because it was using incorrect element names for carbon atoms ("CA", "CB", etc. instead of "C"), which caused bond inference to fail.